### PR TITLE
feat: uses ubi-minimal as a base image for operator

### DIFF
--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -1,3 +1,3 @@
-FROM scratch
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.1
 ADD ior /ior
 ENTRYPOINT [ "/ior" ]


### PR DESCRIPTION
As both [maistra/istio-workspace](https://github.com/Maistra/istio-workspace/blob/7ebb111e5407e315c1dd6a5784f65dbcc11ce2d2/build/Dockerfile#L1) as well as [maistra/istio-operator](https://github.com/Maistra/istio-operator/blob/maistra-1.1/build/Dockerfile#L1) are based on `ubi-minimal` image, this PR aligns `ior` image to be based on that one as well instead of `scratch`.