### PR TITLE
feat(make): introduces help target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,8 @@
 ## See the License for the specific language governing permissions and
 ## limitations under the License.
 
-default: build
+##@ Default target (all you need - just run "make")
+default: build ## runs build
 
 GOBINARY ?= go
 EXE = ior
@@ -31,7 +32,6 @@ ifeq ($(GITREVISION),)
 endif
 LD_EXTRAFLAGS += -X github.com/maistra/ior/pkg/version.buildGitRevision=${GITREVISION}
 
-
 GITSTATUS ?= $(shell git diff-index --quiet HEAD --  2> /dev/null; echo $$?)
 ifeq ($(GITSTATUS),0)
   GITSTATUS = Clean
@@ -48,26 +48,37 @@ ifeq ($(GITTAG),)
 endif
 LD_EXTRAFLAGS += -X github.com/maistra/ior/pkg/version.buildTag=${GITTAG}
 
-clean:
+##@ Build targets
+
+clean: ##
 	rm -f ./cmd/${EXE} && rm -f container/${EXE}
 
 LDFLAGS = '-extldflags -static ${LD_EXTRAFLAGS}'
-build:
+build: ##
 	CGO_ENABLED=0 ${GOBINARY} build -mod=vendor -o ./cmd/${EXE} -ldflags ${LDFLAGS} ./cmd/...
 
-image: build
+test: ##
+	./tests/test.sh
+
+##@ Image creation
+
+image: build ##
 	cp ./cmd/${EXE} container/ && \
 	cd container && \
 	docker build -t ${HUB}/ior:${TAG} .
 
-push: image
+push: image ##
 	docker push ${HUB}/ior:${TAG}
 
-pod: build image
-	kubectl delete --ignore-not-found=true --now=true ns ${NAMESPACE} && \
-	sed -e "s|\$${HUB}|${HUB}|g" -e "s|\$${TAG}|${TAG}|g" -e "s|\$${NAMESPACE}|${NAMESPACE}|g" container/pod.yaml | kubectl -n ${NAMESPACE} create -f-
+##@ Helpers
 
-cleanPod:
+deploy: ## Deploys operator into defined ${NAMESPACE}
+	sed -e "s|\$${HUB}|${HUB}|g" -e "s|\$${TAG}|${TAG}|g" -e "s|\$${NAMESPACE}|${NAMESPACE}|g" container/pod.yaml | kubectl -n ${NAMESPACE} apply -f-
+
+undeploy: ## Deletes operator from the ${NAMESPACE}
 	sed -e "s|\$${HUB}|${HUB}|g" -e "s|\$${TAG}|${TAG}|g" -e "s|\$${NAMESPACE}|${NAMESPACE}|g" container/pod.yaml | kubectl -n ${NAMESPACE} delete -f-
-test:
-	./tests/test.sh
+
+.PHONY: help
+help:  ## Displays this help \o/
+	@awk 'BEGIN {FS = ":.*##"; printf "\nUsage:\n  make \033[36m<target>\033[0m\n"} /^[a-zA-Z_-]+:.*?##/ { printf "  \033[36m%-25s\033[0m\033[2m %s\033[0m\n", $$1, $$2 } /^##@/ { printf "\n\033[1m%s\033[0m\n", substr($$0, 5) } ' $(MAKEFILE_LIST)
+	@cat $(MAKEFILE_LIST) | grep "^[A-Za-z_]*.?=" | sort | awk 'BEGIN {FS="?="; printf "\n\n\033[1mEnvironment variables\033[0m\n"} {printf "  \033[36m%-25s\033[0m\033[2m %s\033[0m\n", $$1, $$2}'


### PR DESCRIPTION
This PR cleans up `Makefile` and provides simple `help` target which prints all the targets which are annotated with `## comment` as well as all variables which can be set for the build. 

That's how it looks in the console:

![image](https://user-images.githubusercontent.com/719616/73747073-e56b5e80-4756-11ea-8bce-ef1d08ba7b4d.png)


