### PR TITLE
chore: cobra cmd cleanup

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -17,7 +17,7 @@ package main
 import "os"
 
 func main() {
-	rootCmd := getRootCmd(os.Args[1:])
+	rootCmd := newRootCmd()
 
 	if err := rootCmd.Execute(); err != nil {
 		os.Exit(-1)

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -14,12 +14,16 @@
 
 package main
 
-import "os"
+import (
+	"istio.io/pkg/log"
+	"os"
+)
 
 func main() {
 	rootCmd := newRootCmd()
 
 	if err := rootCmd.Execute(); err != nil {
+		log.Error(err.Error())
 		os.Exit(-1)
 	}
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -35,7 +35,9 @@ func newRootCmd() *cobra.Command {
 		Use:   "ior",
 		Short: "Connects to Galley and manages OpenShift Routes based on Istio Gateways",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			log.Configure(loggingOptions)
+			if err := log.Configure(loggingOptions); err != nil {
+				return err
+			}
 
 			log.Infof("Starting IOR %s", version.Info)
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -32,7 +32,7 @@ var (
 func getRootCmd(args []string) *cobra.Command {
 
 	rootCmd := &cobra.Command{
-		Use:   "server",
+		Use:   "ior",
 		Short: "Connects to Galley and manages OpenShift Routes based on Istio Gateways",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			log.Configure(loggingOptions)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -29,7 +29,7 @@ var (
 	cliArgs        = bootstrap.DefaultArgs()
 )
 
-func getRootCmd(args []string) *cobra.Command {
+func newRootCmd() *cobra.Command {
 
 	rootCmd := &cobra.Command{
 		Use:   "ior",
@@ -48,7 +48,6 @@ func getRootCmd(args []string) *cobra.Command {
 		},
 	}
 
-	rootCmd.SetArgs(args)
 	rootCmd.PersistentFlags().AddGoFlagSet(flag.CommandLine)
 	rootCmd.PersistentFlags().StringVarP(&cliArgs.McpAddr, "mcp-address", "", cliArgs.McpAddr,
 		"Galley's MCP server address")


### PR DESCRIPTION
Few minor improvements in the way `cobra` library is used here.

1. root cmd, by convention, is named as the final binary. With `server` we refer to non-existing command in help, making output quite confusing for the user.

```
╰─ ior --help  
Connects to Galley and manages OpenShift Routes based on Istio Gateways

Usage:
  server [flags]
  server [command]

Available Commands:
  help        Help about any command
  version     Prints version number and exits

Flags:
....
Use "server [command] --help" for more information about a command.
```

which in fact should be

```
╰─ ior --help  
Connects to Galley and manages OpenShift Routes based on Istio Gateways

Usage:
  ior [flags]
  ior [command]

Available Commands:
  help        Help about any command
  version     Prints version number and exits

Flags:
....
Use "server [command] --help" for more information about a command.
```

2. There's no need to pass arguments explicitly to Cobra, thus I removed those bits

3. Added extra error handling and logging around root cmd
