### PR TITLE
MAISTRA-1153: adds ability to read pods and services

### DIFF
--- a/container/pod.yaml
+++ b/container/pod.yaml
@@ -22,6 +22,9 @@ rules:
 - apiGroups: ["route.openshift.io"]
   resources: ["routes", "routes/custom-host"]
   verbs: ["get", "list", "watch", "create", "delete"]
+- apiGroups: [""]
+  resources: ["services", "pods"]
+  verbs: ["get", "list"]
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1


### PR DESCRIPTION
Without added rules for `ClusterRole` IOR fails when deployed to the same ns as istio system.

```
2020-02-05T12:44:46.523995Z    info    Got info from MCP - 1 object(s)

2020-02-05T12:44:46.524083Z    debug    Object 1: Metadata = name:"ike-ior-test/test-gateway" create_time:<seconds:1580906603 > version:"1078371" annotations:<key:"kubectl.kubernetes.io/last-applied-configuration" value:"{\"apiVersion\":\"networking.istio.io/v1alpha3\",\"kind\":\"Gateway\",\"metadata\":{\"annotations\":{},\"creationTimestamp\":null,\"name\":\"test-gateway\",\"namespace\":\"ike-ior-test\"},\"spec\":{\"selector\":{\"istio\":\"ingressgateway\"},\"servers\":[{\"hosts\":[\"*\"],\"port\":{\"name\":\"http\",\"number\":80,\"protocol\":\"HTTP\"}}]}}\n" >  
2020-02-05T12:44:46.524115Z    debug    Object 1: Gateway = servers:<port:<number:80 protocol:"HTTP" name:"http" > hosts:"*" > selector:<key:"istio" value:"ingressgateway" > 

2020-02-05T12:44:46.524123Z    debug    Creating route for hostname *
2020-02-05T12:44:46.524130Z    info    Gateway ike-ior-test/test-gateway: Wildcard * is not supported at the moment. Letting OpenShift create the hostname instead.
2020-02-05T12:44:46.527736Z    error    Error creating a route for host * (gateway ike-ior-test/test-gateway): could not get the list of pods: pods is forbidden: User "system:serviceaccount:istio-system:ior" cannot list resource "pods" in API group "" in the namespace "istio-system"
2020-02-05T12:44:46.527773Z    debug    Current state: 0 item(ns)
```