### PR TITLE
[MAISTRA-1744] Route annotation propagation

### DIFF
--- a/pkg/route/route.go
+++ b/pkg/route/route.go
@@ -193,6 +193,15 @@ func (r *Route) createRoute(metadata *mcp.Metadata, gateway *networking.Gateway,
 		return
 	}
 
+	annotations := map[string]string{
+		originalHostAnnotation: originalHost,
+	}
+	for keyName, keyValue := range metadata.Annotations {
+		if !strings.HasPrefix(keyName, "kubectl.kubernetes.io") {
+			annotations[keyName] = keyValue
+		}
+	}
+
 	nr, err := r.client.Routes(serviceNamespace).Create(&v1.Route{
 		ObjectMeta: metav1.ObjectMeta{
 			GenerateName: fmt.Sprintf("%s-%s-", gatewayNamespace, gatewayName),
@@ -201,9 +210,7 @@ func (r *Route) createRoute(metadata *mcp.Metadata, gateway *networking.Gateway,
 				gatewayNamespaceLabel: gatewayNamespace,
 				gatewayNameLabel:      gatewayName,
 			},
-			Annotations: map[string]string{
-				originalHostAnnotation: originalHost,
-			},
+			Annotations: annotations,
 		},
 		Spec: v1.RouteSpec{
 			Host: actualHost,


### PR DESCRIPTION
Backport for version 1.2

This adds route annotation propagation to generated Openshift routes from Istio gateways. currently only excluding annotations from kubectl.kubernetes.io to reduce confusion. Could be more keys we would want to ignore, I'm open to discuss.

Changes allow use of https://github.com/tnozicka/openshift-acme specific annoations within Istio generated routes.

https://issues.redhat.com/browse/MAISTRA-1744

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[x] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure